### PR TITLE
Add changelog display in update modal

### DIFF
--- a/app_src/components/modal/modal.jsx
+++ b/app_src/components/modal/modal.jsx
@@ -6,6 +6,7 @@ import HelpModal from './help';
 import SettingsModal from './settings';
 import EditStyleModal from './editStyle';
 import EditFolderModal from './editFolder';
+import UpdateModal from './update';
 
 
 const Modal = React.memo(function Modal() {
@@ -17,6 +18,7 @@ const Modal = React.memo(function Modal() {
     else if (modalType === 'settings') modalContent = <SettingsModal />;
     else if (modalType === 'editStyle') modalContent = <EditStyleModal />;
     else if (modalType === 'editFolder') modalContent = <EditFolderModal />;
+    else if (modalType === 'update') modalContent = <UpdateModal />;
 
     React.useEffect(() => {
         if (!context.state.notFirstTime) {

--- a/app_src/components/modal/update.jsx
+++ b/app_src/components/modal/update.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { FiX } from 'react-icons/fi';
+
+import { locale, openUrl } from '../../utils';
+import { useContext } from '../../context';
+
+const UpdateModal = React.memo(function UpdateModal() {
+  const context = useContext();
+  const { version, body } = context.state.modalData;
+  const close = () => {
+    context.dispatch({ type: 'setModal' });
+  };
+  const download = () => {
+    openUrl('https://github.com/ScanR/TypeR/releases/latest');
+    close();
+  };
+  return (
+    <React.Fragment>
+      <div className="app-modal-header hostBrdBotContrast">
+        <div className="app-modal-title">{locale.updateTitle}</div>
+        <button className="topcoat-icon-button--large--quiet" title={locale.close} onClick={close}>
+          <FiX size={18} />
+        </button>
+      </div>
+      <div className="app-modal-body">
+        <div className="app-modal-body-inner article-format">
+          <p>{locale.updateText.replace('{version}', version)}</p>
+          {body && (
+            <React.Fragment>
+              <h4>{locale.updateChanges}</h4>
+              <div dangerouslySetInnerHTML={{ __html: body }} />
+            </React.Fragment>
+          )}
+        </div>
+      </div>
+      <div className="app-modal-footer hostBrdTopContrast">
+        <button className="topcoat-button--large" onClick={download}>{locale.updateDownload}</button>
+      </div>
+    </React.Fragment>
+  );
+});
+
+export default UpdateModal;

--- a/app_src/context.jsx
+++ b/app_src/context.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { locale, readStorage, writeToStorage, scrollToLine, scrollToStyle } from "./utils";
+import { locale, readStorage, writeToStorage, scrollToLine, scrollToStyle, checkUpdate } from "./utils";
+import config from "./config";
 
 const storage = readStorage();
 const storeFields = ["notFirstTime", "text", "styles", "folders", "textScale", "currentLineIndex", "currentStyleId", "pastePointText", "ignoreLinePrefixes", "defaultStyleId", "shortcut"];
@@ -371,6 +372,13 @@ const useContext = () => React.useContext(Context);
 const ContextProvider = React.memo(function ContextProvider(props) {
   const [state, dispatch] = React.useReducer(reducer, initialState);
   React.useEffect(() => dispatch({}), []);
+  React.useEffect(() => {
+    checkUpdate(config.appVersion).then((data) => {
+      if (data) {
+        dispatch({ type: 'setModal', modal: 'update', data });
+      }
+    });
+  }, []);
   return <Context.Provider value={{ state, dispatch }}>{props.children}</Context.Provider>;
 });
 ContextProvider.propTypes = {

--- a/app_src/utils.js
+++ b/app_src/utils.js
@@ -8,6 +8,23 @@ const locale = csInterface.initResourceBundle();
 
 const openUrl = window.cep.util.openURLInDefaultBrowser;
 
+const checkUpdate = async (currentVersion) => {
+  try {
+    const response = await fetch(
+      "https://api.github.com/repos/ScanR/TypeR/releases/latest",
+      { headers: { Accept: "application/vnd.github.v3.html+json" } }
+    );
+    if (!response.ok) return null;
+    const data = await response.json();
+    if (data.tag_name && data.tag_name !== currentVersion) {
+      return { version: data.tag_name, body: data.body_html || data.body };
+    }
+  } catch (e) {
+    console.error("Update check failed", e);
+  }
+  return null;
+};
+
 const readStorage = (key) => {
   const result = window.cep.fs.readFile(storagePath);
   if (result.err) {
@@ -221,4 +238,4 @@ const openFile = (path) => {
   csInterface.evalScript("openFile('" + path + "')");
 };
 
-export { csInterface, locale, openUrl, readStorage, writeToStorage, nativeAlert, nativeConfirm, getUserFonts, getActiveLayerText, setActiveLayerText, createTextLayerInSelection, alignTextLayerToSelection, changeActiveLayerTextSize, getHotkeyPressed, resizeTextArea, scrollToLine, scrollToStyle, rgbToHex, getStyleObject, getDefaultStyle, openFile };
+export { csInterface, locale, openUrl, readStorage, writeToStorage, nativeAlert, nativeConfirm, getUserFonts, getActiveLayerText, setActiveLayerText, createTextLayerInSelection, alignTextLayerToSelection, changeActiveLayerTextSize, getHotkeyPressed, resizeTextArea, scrollToLine, scrollToStyle, rgbToHex, getStyleObject, getDefaultStyle, openFile, checkUpdate };

--- a/locale/de_DE/messages.properties
+++ b/locale/de_DE/messages.properties
@@ -177,3 +177,10 @@ shortcut_next=Nächste Zeile
 shortcut_previous=Vorherige Zeile
 shortcut_increase=Textgröße Vergrößern
 shortcut_decrease=Textgröße Verkleinern
+
+## update
+updateTitle=Update verfügbar
+updateText=Version {version} ist verfügbar.
+updateDownload=Herunterladen
+updateChanges=Änderungsprotokoll
+

--- a/locale/es_SP/messages.properties
+++ b/locale/es_SP/messages.properties
@@ -177,3 +177,10 @@ shortcut_next=Línea Siguiente
 shortcut_previous=Línea Anterior
 shortcut_increase=Aumentar Tamaño del Texto
 shortcut_decrease=Disminuir Tamaño del Texto
+
+## update
+updateTitle=Actualización disponible
+updateText=Versión {version} disponible.
+updateDownload=Descargar
+updateChanges=Registro de cambios
+

--- a/locale/fr_FR/messages.properties
+++ b/locale/fr_FR/messages.properties
@@ -178,3 +178,10 @@ shortcut_next=Ligne suivante
 shortcut_previous=Ligne précédente
 shortcut_increase=Augmenter taille du texte
 shortcut_decrease=Diminuer taille du texte
+
+## update
+updateTitle=Mise à jour disponible
+updateText=La version {version} est disponible.
+updateDownload=Télécharger
+updateChanges=Journal des modifications
+

--- a/locale/messages.properties
+++ b/locale/messages.properties
@@ -178,3 +178,10 @@ shortcut_next=Next line
 shortcut_previous=Previous line
 shortcut_increase=Increase text size
 shortcut_decrease=Decrease text size
+
+## update
+updateTitle=Update available
+updateText=Version {version} is available.
+updateDownload=Download
+updateChanges=Changelog
+

--- a/locale/pt_BR/messages.properties
+++ b/locale/pt_BR/messages.properties
@@ -177,3 +177,10 @@ shortcut_next=Próxima Linha
 shortcut_previous=Linha Anterior
 shortcut_increase=Aumentar Tamanho do Texto
 shortcut_decrease=Diminuir Tamanho do Texto
+
+## update
+updateTitle=Atualização disponível
+updateText=Versão {version} disponível.
+updateDownload=Baixar
+updateChanges=Registro de alterações
+

--- a/locale/ru_RU/messages.properties
+++ b/locale/ru_RU/messages.properties
@@ -176,3 +176,10 @@ shortcut_next=Следующая Строка
 shortcut_previous=Предыдущая Строка
 shortcut_increase=Увеличить Размер Текста
 shortcut_decrease=Уменьшить Размер Текста
+
+## update
+updateTitle=Доступно обновление
+updateText=Доступна версия {version}.
+updateDownload=Скачать
+updateChanges=Список изменений
+

--- a/locale/tr_TR/messages.properties
+++ b/locale/tr_TR/messages.properties
@@ -177,3 +177,10 @@ shortcut_next=Sonraki Satır
 shortcut_previous=Önceki Satır
 shortcut_increase=Yazı Boyutunu Artır
 shortcut_decrease=Yazı Boyutunu Azalt
+
+## update
+updateTitle=Güncelleme mevcut
+updateText={version} sürümü mevcut.
+updateDownload=İndir
+updateChanges=Değişiklik listesi
+

--- a/locale/uk_UA/messages.properties
+++ b/locale/uk_UA/messages.properties
@@ -177,3 +177,10 @@ shortcut_next=Наступний Рядок
 shortcut_previous=Попередній Рядок
 shortcut_increase=Збільшити Розмір Тексту
 shortcut_decrease=Зменшити Розмір Тексту
+
+## update
+updateTitle=Доступне оновлення
+updateText=Доступна версія {version}.
+updateDownload=Завантажити
+updateChanges=Список змін
+

--- a/locale/vi_VN/messages.properties
+++ b/locale/vi_VN/messages.properties
@@ -178,3 +178,10 @@ shortcut_next=Dòng Tiếp Theo
 shortcut_previous=Dòng Trước
 shortcut_increase=Tăng Kích Thước Văn Bản
 shortcut_decrease=Giảm Kích Thước Văn Bản
+
+## update
+updateTitle=Có bản cập nhật
+updateText=Phiên bản {version} đã có sẵn.
+updateDownload=Tải về
+updateChanges=Nhật ký thay đổi
+


### PR DESCRIPTION
## Summary
- enrich update checker with release body
- display release notes in Update modal
- add `updateChanges` string across locales

## Testing
- `npm run build` *(fails: rimraf not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405db221e4832f80316e306d47a3ac