### PR TITLE
Fix translation key omissions

### DIFF
--- a/locale/de_DE/messages.properties
+++ b/locale/de_DE/messages.properties
@@ -1,5 +1,6 @@
 ## errors
 errorTitle=Fehler
+successTitle=Erfolg
 errorNoText=Kein Text ausgewählt.
 errorNoTextNoStyle=Weder Text noch Style ausgewählt.
 errorNoTextLayer=Kein Text Layer ausgewählt.
@@ -76,7 +77,10 @@ settingsLanguageAuto=Automatisch
 settingsAutoClosePsdLabel=PSD automatisch schließen
 settingsImport=Alle Einstellungen und Stile importieren
 settingsExport=Alle Einstellungen und Stile exportieren
+exportIncludeSettings=Meine Einstellungen exportieren
 settingsImportReplace=Möchten Sie Stile behalten, die beim Import fehlen oder ein späteres Bearbeitungsdatum haben?
+importFolderSuccess=Style-Ordner erfolgreich importiert
+importFoldersSuccess=Style-Ordner erfolgreich importiert
 
 ## edit style
 editStyleTitle=Style Bearbeitung
@@ -162,6 +166,7 @@ stylePrefixColor=Tag Farbe
 editFolder=Bearbeite Ordner
 exportFolder=Exportiere Ordner
 editStyle=Bearbeite Style
+duplicateFolder=Ordner duplizieren
 insertStyle=Wende Style auf ausgewähltes Layer an
 addFolder=Füge Ordner hinzu
 addStyle=Füge Style hinzu

--- a/locale/es_SP/messages.properties
+++ b/locale/es_SP/messages.properties
@@ -1,5 +1,6 @@
 ## errors
 errorTitle=Error
+successTitle=Éxito
 errorNoText=No se ha especificado ningún texto.
 errorNoTextNoStyle=No se ha especificado ni texto ni estilo.
 errorNoTextLayer=No se ha especificado ninguna capa de texto.
@@ -76,7 +77,10 @@ settingsLanguageAuto=Automático
 settingsAutoClosePsdLabel=Cerrar automáticamente el PSD
 settingsImport=Importar todas las configuraciones y estilos
 settingsExport=Exportar todas las configuraciones y estilos
+exportIncludeSettings=Exportar mis ajustes
 settingsImportReplace=¿Desea conservar los estilos que no están presentes en la importación o tienen una fecha de edición posterior?
+importFolderSuccess=Carpeta de estilos importada correctamente
+importFoldersSuccess=Carpetas de estilos importadas correctamente
 
 ## edit style
 editStyleTitle=Edición de estilo
@@ -162,6 +166,7 @@ stylePrefixColor=Color de la etiqueta
 editFolder=Editar carpeta
 exportFolder=Exportar carpeta
 editStyle=Editar estilo
+duplicateFolder=Duplicar carpeta
 insertStyle=Aplicar estilo a la capa actual
 addFolder=Añadir carpeta
 addStyle=Añadir estilo

--- a/locale/pt_BR/messages.properties
+++ b/locale/pt_BR/messages.properties
@@ -1,5 +1,6 @@
 ## erros
 errorTitle=Erro
+successTitle=Sucesso
 errorNoText=Nenhum texto foi especificado.
 errorNoTextNoStyle=Nem texto, nem estilo foram especificados.
 errorNoTextLayer=Nenhuma camada de texto foi especificada.
@@ -76,7 +77,10 @@ settingsLanguageAuto=Automático
 settingsAutoClosePsdLabel=Fechar PSD automaticamente
 settingsImport=Importar todas as configurações e estilos
 settingsExport=Exportar todas as configurações e estilos
+exportIncludeSettings=Exportar minhas configurações
 settingsImportReplace=Deseja manter os estilos que não estão presentes na importação ou ter uma data de edição posterior?
+importFolderSuccess=Pasta de estilos importada com sucesso
+importFoldersSuccess=Pastas de estilos importadas com sucesso
 
 ## editar estilo
 editStyleTitle=Editar estilo
@@ -158,10 +162,11 @@ addStylesHint=Adicionar estilo que serão aplicados ao texto colado
 noStylesInfolder=Não há estilos na pasta
 noFolderTitle=Não classificado
 styleTextColor=Cor do texto
-estiloPrefixColor=Cor da tag
+stylePrefixColor=Cor da tag
 editFolder=Editar pasta
 exportFolder=Exportar pasta
 editStyle=Editar estilo
+duplicateFolder=Duplicar pasta
 insertStyle=Aplicar estilo à camada atual
 addFolder=Adicionar pasta
 addStyle=Adicionar estilo

--- a/locale/ru_RU/messages.properties
+++ b/locale/ru_RU/messages.properties
@@ -1,5 +1,6 @@
 ## errors
 errorTitle=Ошибка
+successTitle=Успех
 errorNoText=Не выбран текст.
 errorNoTextNoStyle=Не выбран ни текст, ни стиль.
 errorNoTextLayer=Не выбран текстовый слой.
@@ -75,7 +76,10 @@ settingsLanguageAuto=Авто
 settingsAutoClosePsdLabel=Автоматически закрывать PSD
 settingsImport=Импортировать все параметры и стили
 settingsExport=Экспортировать все параметры и стили
+exportIncludeSettings=Экспорт моих настроек
 settingsImportReplace=Хотите ли вы сохранить стили, которые отсутствуют в импорте или имеют более поздную дату редактирования?
+importFolderSuccess=Папка стилей успешно импортирована
+importFoldersSuccess=Папки стилей успешно импортированы
 
 ## edit style
 editStyleTitle=Редактирование стиля
@@ -161,6 +165,7 @@ stylePrefixColor=Цвет префикса
 editFolder=Редактировать папку
 exportFolder=Экспортировать папку
 editStyle=Редактировать стиль
+duplicateFolder=Дублировать папку
 insertStyle=Применить стиль к текущему слою
 addFolder=Добавить папку
 addStyle=Добавить стиль

--- a/locale/tr_TR/messages.properties
+++ b/locale/tr_TR/messages.properties
@@ -1,5 +1,6 @@
 ## errors
 errorTitle=Hata
+successTitle=Başarılı
 errorNoText=Metin belirtilmedi.
 errorNoTextNoStyle=Ne metin, ne de stil belirtilmedi.
 errorNoTextLayer=Hiçbir metin katmanı belirtilmedi.
@@ -76,7 +77,10 @@ settingsLanguageAuto=Otomatik
 settingsAutoClosePsdLabel=PSD yi otomatik kapat
 settingsImport=Ayarları ve stilleri içe aktarın
 settingsExport=Ayarları ve stilleri dışa aktarın
+exportIncludeSettings=Ayarlarımı dışa aktar
 settingsImportReplace=İçe aktarmada bulunmayan veya düzenleme tarihi daha sonra olan stilleri saklamak istiyor musunuz?
+importFolderSuccess=Stil klasörü başarıyla içe aktarıldı
+importFoldersSuccess=Stil klasörleri başarıyla içe aktarıldı
 
 ## edit style
 editStyleTitle=Stil düzenleme
@@ -162,6 +166,7 @@ stylePrefixColor=Etiket rengi
 editFolder=Klasörü düzenle
 exportFolder=Klasörü dışa aktar
 editStyle=Stili düzenle
+duplicateFolder=Klasörü çoğalt
 insertStyle=Geçerli katmana stili uygula
 addFolder=Klasör ekle
 addStyle=Stil ekle

--- a/locale/uk_UA/messages.properties
+++ b/locale/uk_UA/messages.properties
@@ -1,5 +1,6 @@
 ## errors
 errorTitle=Помилка
+successTitle=Успішно
 errorNoText=Не обрано текст.
 errorNoTextNoStyle=Не обрано ні стилю, ні тексту.
 errorNoTextLayer=Не обраний текстовий шар.
@@ -76,7 +77,10 @@ settingsLanguageAuto=Авто
 settingsAutoClosePsdLabel=Автоматично закривати PSD
 settingsImport=Імпортувати всі налаштування та стилі
 settingsExport=Експортувати всі налаштування та стилі
+exportIncludeSettings=Експортувати мої налаштування
 settingsImportReplace=Чи бажаєте зберегти стилі, які відсутні в імпортованих або мають пізнішу дату редагування?
+importFolderSuccess=Тека стилів успішно імпортована
+importFoldersSuccess=Теки стилів успішно імпортовані
 
 ## edit style
 editStyleTitle=Редагування стилю
@@ -162,6 +166,7 @@ stylePrefixColor=Колір префіксу
 editFolder=Редагувати теку
 exportFolder=Експортувати теку
 editStyle=Редагувати стиль
+duplicateFolder=Дублювати теку
 insertStyle=Застосувати стиль до активного шару
 addFolder=Додати теку
 addStyle=Додати стиль

--- a/locale/vi_VN/messages.properties
+++ b/locale/vi_VN/messages.properties
@@ -1,5 +1,6 @@
 ## lỗi
 errorTitle=Lỗi
+successTitle=Thành công
 errorNoText=Không có văn bản nào được chọn.
 errorNoTextNoStyle=Không có văn bản và kiểu cách nào được chọn.
 errorNoTextLayer=Không có lớp văn bản nào được chọn.
@@ -77,7 +78,10 @@ settingsLanguageAuto=Tự động
 settingsAutoClosePsdLabel=Tự động đóng PSD
 settingsImport=Nhập tất cả cài đặt và các kiểu
 settingsExport=Xuất tất cả cài đặt và các kiểu
+exportIncludeSettings=Xuất cài đặt của tôi
 settingsImportReplace=Bạn có muốn giữ lại các kiểu cách chưa được lưu không? Các kiểu cách này không có trong tập tin hoặc có thể đã được chỉnh sửa mà chưa được xuất lại vào tập tin.
+importFolderSuccess=Thư mục kiểu đã được nhập thành công
+importFoldersSuccess=Các thư mục kiểu đã được nhập thành công
 
 ## chỉnh sửa kiểu cách
 editStyleTitle=Chỉnh sửa kiểu cách
@@ -163,6 +167,7 @@ stylePrefixColor=Màu ký hiệu
 editFolder=Chỉnh sửa thư mục
 exportFolder=Xuất thư mục
 editStyle=Chỉnh sửa kiểu cách
+duplicateFolder=Nhân đôi thư mục
 insertStyle=Áp dụng kiểu cách cho lớp đang chọn
 addFolder=Thêm thư mục
 addStyle=Thêm kiểu cách


### PR DESCRIPTION
- add missing `successTitle` and style import/export messages across locale files
- fix typo `estiloPrefixColor` -> `stylePrefixColor`
- add `duplicateFolder` key for non-English locales