### PR TITLE
Add optional point text conversion when centering

### DIFF
--- a/app_src/components/modal/export.jsx
+++ b/app_src/components/modal/export.jsx
@@ -45,6 +45,7 @@ const ExportModal = React.memo(function ExportModal() {
       data.defaultStyleId = context.state.defaultStyleId;
       data.language = context.state.language;
       data.autoClosePSD = context.state.autoClosePSD;
+      data.alignPointToParagraph = context.state.alignPointToParagraph;
       data.textItemKind = context.state.setTextItemKind;
     }
     window.cep.fs.writeFile(pathSelect.data, JSON.stringify(data));

--- a/app_src/components/modal/settings.jsx
+++ b/app_src/components/modal/settings.jsx
@@ -11,6 +11,9 @@ import Shortcut from "./shortCut";
 const SettingsModal = React.memo(function SettingsModal() {
   const context = useContext();
   const [pastePointText, setPastePointText] = React.useState(context.state.pastePointText ? "1" : "");
+  const [alignPointToParagraph, setAlignPointToParagraph] = React.useState(
+    !!context.state.alignPointToParagraph
+  );
   const [ignoreLinePrefixes, setIgnoreLinePrefixes] = React.useState(context.state.ignoreLinePrefixes.join(" "));
   const [defaultStyleId, setDefaultStyleId] = React.useState(context.state.defaultStyleId || "");
   const [language, setLanguage] = React.useState(context.state.language || "auto");
@@ -51,6 +54,11 @@ const SettingsModal = React.memo(function SettingsModal() {
     setEdited(true);
   };
 
+  const changeAlignPointToParagraph = (e) => {
+    setAlignPointToParagraph(e.target.checked);
+    setEdited(true);
+  };
+
   const changeCheckUpdates = (e) => {
     setCheckUpdates(e.target.checked);
     setEdited(true);
@@ -87,6 +95,12 @@ const SettingsModal = React.memo(function SettingsModal() {
       context.dispatch({
         type: "setAutoClosePSD",
         value: autoClosePSD,
+      });
+    }
+    if (alignPointToParagraph !== context.state.alignPointToParagraph) {
+      context.dispatch({
+        type: "setAlignPointToParagraph",
+        value: alignPointToParagraph,
       });
     }
     if (checkUpdates !== context.state.checkUpdates) {
@@ -144,6 +158,7 @@ const SettingsModal = React.memo(function SettingsModal() {
             !data.defaultStyleId &&
             !data.language &&
             !data.autoClosePSD &&
+            !data.alignPointToParagraph &&
             !data.textItemKind
           ) {
             const idMap = {};
@@ -267,6 +282,15 @@ const SettingsModal = React.memo(function SettingsModal() {
               <div className="field-input">
                 <label className="topcoat-checkbox">
                   <input type="checkbox" checked={autoClosePSD} onChange={changeAutoClosePSD} />
+                  <div className="topcoat-checkbox__checkmark"></div>
+                </label>
+              </div>
+            </div>
+            <div className="field hostBrdTopContrast">
+              <div className="field-label">{locale.settingsConvertPointLabel}</div>
+              <div className="field-input">
+                <label className="topcoat-checkbox">
+                  <input type="checkbox" checked={alignPointToParagraph} onChange={changeAlignPointToParagraph} />
                   <div className="topcoat-checkbox__checkmark"></div>
                 </label>
               </div>

--- a/app_src/components/previewBlock/previewBlock.jsx
+++ b/app_src/components/previewBlock/previewBlock.jsx
@@ -72,7 +72,7 @@ const PreviewBlock = React.memo(function PreviewBlock() {
         <button className="preview-top_big-btn topcoat-button--large--cta" title={locale.createLayerDescr} onClick={createLayer}>
           <AiOutlineBorderInner size={18} /> {locale.createLayer}
         </button>
-        <button className="preview-top_big-btn topcoat-button--large" title={locale.alignLayerDescr} onClick={() => alignTextLayerToSelection()}>
+        <button className="preview-top_big-btn topcoat-button--large" title={locale.alignLayerDescr} onClick={() => alignTextLayerToSelection(context.state.alignPointToParagraph)}>
           <MdCenterFocusWeak size={18} /> {locale.alignLayer}
         </button>
         <div className="preview-top_change-size-cont">

--- a/app_src/context.jsx
+++ b/app_src/context.jsx
@@ -13,6 +13,7 @@ const storeFields = [
   "currentLineIndex",
   "currentStyleId",
   "pastePointText",
+  "alignPointToParagraph",
   "ignoreLinePrefixes",
   "defaultStyleId",
   "autoClosePSD",
@@ -36,6 +37,7 @@ const initialState = {
   currentStyle: null,
   currentStyleId: null,
   pastePointText: false,
+  alignPointToParagraph: false,
   ignoreLinePrefixes: ["##"],
   defaultStyleId: null,
   autoClosePSD: false,
@@ -273,6 +275,11 @@ const reducer = (state, action) => {
 
   case "setPastePointText": {
     newState.pastePointText = !!action.isPoint;
+    break;
+  }
+
+  case "setAlignPointToParagraph": {
+    newState.alignPointToParagraph = !!action.value;
     break;
   }
 

--- a/app_src/host.js
+++ b/app_src/host.js
@@ -469,6 +469,7 @@ function _createTextLayerInSelection() {
 }
 
 var alignTextLayerToSelectionResult;
+var alignTextLayerToSelectionConvert;
 
 function _alignTextLayerToSelection() {
   if (!documents.length) {
@@ -492,7 +493,11 @@ function _alignTextLayerToSelection() {
   var isPoint = _textLayerIsPointText();
   var bounds = _getCurrentTextLayerBounds();
   if (isPoint) {
-    _changeToPointText();
+    if (alignTextLayerToSelectionConvert) {
+      _changeToBoxText();
+    } else {
+      _changeToPointText();
+    }
   }
   _deselect();
   var offsetX = selection.xMid - bounds.xMid;
@@ -700,7 +705,8 @@ function createTextLayerInSelection(data, point) {
   return createTextLayerInSelectionResult;
 }
 
-function alignTextLayerToSelection() {
+function alignTextLayerToSelection(convert) {
+  alignTextLayerToSelectionConvert = convert;
   app.activeDocument.suspendHistory("TyperTools Align", "_alignTextLayerToSelection()");
   return alignTextLayerToSelectionResult;
 }

--- a/app_src/hotkeys.jsx
+++ b/app_src/hotkeys.jsx
@@ -75,7 +75,7 @@ const HotkeysListner = React.memo(function HotkeysListner() {
       });
     } else if (checkShortcut(realState, context.state.shortcut.center)) {
       if (!checkRepeatTime()) return;
-      alignTextLayerToSelection();
+      alignTextLayerToSelection(context.state.alignPointToParagraph);
     } else if (checkShortcut(realState, context.state.shortcut.next)) {
       if (!checkRepeatTime(300)) return;
       context.dispatch({ type: "nextLine" });

--- a/app_src/utils.js
+++ b/app_src/utils.js
@@ -164,8 +164,8 @@ const createTextLayerInSelection = (text, style, pointText, callback = () => {})
   });
 };
 
-const alignTextLayerToSelection = () => {
-  csInterface.evalScript("alignTextLayerToSelection()", (error) => {
+const alignTextLayerToSelection = (convert) => {
+  csInterface.evalScript("alignTextLayerToSelection(" + !!convert + ")", (error) => {
     if (error === "smallSelection") nativeAlert(locale.errorSmallSelection, locale.errorTitle, true);
     else if (error === "noSelection") nativeAlert(locale.errorNoSelection, locale.errorTitle, true);
     else if (error) nativeAlert(locale.errorNoTextLayer, locale.errorTitle, true);

--- a/locale/de_DE/messages.properties
+++ b/locale/de_DE/messages.properties
@@ -76,6 +76,7 @@ settingsDefaultStyleDescr=(Optional) Wähle den Style aus welcher automatisch au
 settingsLanguageLabel=Sprache
 settingsLanguageAuto=Automatisch
 settingsAutoClosePsdLabel=PSD automatisch schließen
+settingsConvertPointLabel=Punkttext beim Zentrieren in Absatztext umwandeln
 settingsCheckUpdatesLabel=Automatisch nach Updates suchen
 settingsCheckUpdatesButton=Nach Updates suchen
 settingsImport=Alle Einstellungen und Stile importieren

--- a/locale/es_SP/messages.properties
+++ b/locale/es_SP/messages.properties
@@ -76,6 +76,7 @@ settingsDefaultStyleDescr=(Opcional) Establezca el estilo, que se activará auto
 settingsLanguageLabel=Idioma
 settingsLanguageAuto=Automático
 settingsAutoClosePsdLabel=Cerrar automáticamente el PSD
+settingsConvertPointLabel=Transformar texto de punto en texto de párrafo al centrar
 settingsCheckUpdatesLabel=Buscar actualizaciones automáticamente
 settingsCheckUpdatesButton=Buscar actualizaciones
 settingsImport=Importar todas las configuraciones y estilos

--- a/locale/fr_FR/messages.properties
+++ b/locale/fr_FR/messages.properties
@@ -76,6 +76,7 @@ settingsDefaultStyleDescr=(Facultatif) Définir le style qui sera automatiquemen
 settingsLanguageLabel=Langue
 settingsLanguageAuto=Automatique
 settingsAutoClosePsdLabel=Fermer automatiquement le PSD
+settingsConvertPointLabel=Transformer le texte ponctuel en texte de paragraphe lors du centrage
 settingsCheckUpdatesLabel=Rechercher automatiquement les mises à jour
 settingsCheckUpdatesButton=Rechercher les mises à jour
 settingsImport=Importer des styles ou paramètres

--- a/locale/messages.properties
+++ b/locale/messages.properties
@@ -76,6 +76,7 @@ settingsDefaultStyleDescr=(Optional) Set the style, which will automatically bec
 settingsLanguageLabel=Language
 settingsLanguageAuto=Auto
 settingsAutoClosePsdLabel=Auto close PSD
+settingsConvertPointLabel=Transform point text into paragraph text when centering
 settingsCheckUpdatesLabel=Check for updates automatically
 settingsCheckUpdatesButton=Check for updates
 settingsImport=Import styles or settings

--- a/locale/pt_BR/messages.properties
+++ b/locale/pt_BR/messages.properties
@@ -76,6 +76,7 @@ settingsDefaultStyleDescr=(Opcional) Defina o estilo, que automaticamente se tor
 settingsLanguageLabel=Idioma
 settingsLanguageAuto=Automático
 settingsAutoClosePsdLabel=Fechar PSD automaticamente
+settingsConvertPointLabel=Transformar texto de ponto em texto de parágrafo ao centralizar
 settingsCheckUpdatesLabel=Verificar atualizações automaticamente
 settingsCheckUpdatesButton=Verificar atualizações
 settingsImport=Importar todas as configurações e estilos

--- a/locale/ru_RU/messages.properties
+++ b/locale/ru_RU/messages.properties
@@ -75,6 +75,7 @@ settingsDefaultStyleDescr=(Опционально) Укажите стиль, к
 settingsLanguageLabel=Язык
 settingsLanguageAuto=Авто
 settingsAutoClosePsdLabel=Автоматически закрывать PSD
+settingsConvertPointLabel=Преобразовывать точечный текст в текст абзаца при центрировании
 settingsCheckUpdatesLabel=Автоматически проверять обновления
 settingsCheckUpdatesButton=Проверить обновления
 settingsImport=Импортировать все параметры и стили

--- a/locale/tr_TR/messages.properties
+++ b/locale/tr_TR/messages.properties
@@ -76,6 +76,7 @@ settingsDefaultStyleDescr=(İsteğe bağlı) Stil etiketi olmayan bir satır se�
 settingsLanguageLabel=Dil
 settingsLanguageAuto=Otomatik
 settingsAutoClosePsdLabel=PSD yi otomatik kapat
+settingsConvertPointLabel=Ortalanırken nokta metnini paragraf metnine dönüştür
 settingsCheckUpdatesLabel=Güncellemeleri otomatik olarak denetle
 settingsCheckUpdatesButton=Güncellemeleri denetle
 settingsImport=Ayarları ve stilleri içe aktarın

--- a/locale/uk_UA/messages.properties
+++ b/locale/uk_UA/messages.properties
@@ -76,6 +76,7 @@ settingsDefaultStyleDescr=(Опціонально) Вкажіть стиль, я
 settingsLanguageLabel=Мова
 settingsLanguageAuto=Авто
 settingsAutoClosePsdLabel=Автоматично закривати PSD
+settingsConvertPointLabel=Перетворювати точковий текст на текст абзацу під час центрування
 settingsCheckUpdatesLabel=Автоматично перевіряти оновлення
 settingsCheckUpdatesButton=Перевірити оновлення
 settingsImport=Імпортувати всі налаштування та стилі

--- a/locale/vi_VN/messages.properties
+++ b/locale/vi_VN/messages.properties
@@ -77,6 +77,7 @@ settingsDefaultStyleDescr=(Tùy chọn) Lựa chọn kiểu cách sẽ được 
 settingsLanguageLabel=Ngôn ngữ
 settingsLanguageAuto=Tự động
 settingsAutoClosePsdLabel=Tự động đóng PSD
+settingsConvertPointLabel=Chuyển văn bản điểm thành văn bản đoạn khi căn giữa
 settingsCheckUpdatesLabel=Tự động kiểm tra cập nhật
 settingsCheckUpdatesButton=Kiểm tra cập nhật
 settingsImport=Nhập tất cả cài đặt và các kiểu


### PR DESCRIPTION
## Summary
- add a new `alignPointToParagraph` setting in context
- let users toggle this setting in the Settings modal
- pass the setting when centering layers
- update host script to convert point text only when option enabled
- translate the new label for all locales