### PR TITLE
chore: remove unused hotkey constants and footer import

### DIFF
--- a/app_src/components/footer/footer.jsx
+++ b/app_src/components/footer/footer.jsx
@@ -1,7 +1,6 @@
 import "./footer.scss";
 
 import React from "react";
-import PropTypes from "prop-types";
 import { locale } from "../../utils";
 import { useContext } from "../../context";
 import HiddenFileInput from "../hiddenFileInput/hiddenFileInput";

--- a/app_src/hotkeys.jsx
+++ b/app_src/hotkeys.jsx
@@ -4,11 +4,6 @@ import React from "react";
 import { csInterface, setActiveLayerText, createTextLayerInSelection, createTextLayersInStoredSelections, alignTextLayerToSelection, getHotkeyPressed, changeActiveLayerTextSize } from "./utils";
 import { useContext } from "./context";
 
-const CTRL = "CTRL";
-const SHIFT = "SHIFT";
-const ALT = "ALT";
-const WIN = "WIN";
-
 const intervalTime = 50;
 let keyboardInterval = 0;
 let keyUp = true;


### PR DESCRIPTION
## Summary
- remove unused key label constants from the hotkey listener
- drop the unused PropTypes import from the footer component

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6903170e1748832fbd691aa6c9128fe6